### PR TITLE
Sherlock's Infrastructure using IntelliJ Platform

### DIFF
--- a/build/src/SherlockPlatformBuild.kt
+++ b/build/src/SherlockPlatformBuild.kt
@@ -1,0 +1,64 @@
+// TODO: Copyright
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.intellij.build.*
+import org.jetbrains.intellij.build.impl.BuildContextImpl
+
+
+@Suppress("RAW_RUN_BLOCKING", "UNUSED")
+object SherlockPlatformBuild {
+  @JvmStatic
+  fun main() {
+    runBlocking {
+      val home = IdeaProjectLoaderUtil.guessCommunityHome(javaClass)
+      val properties = SherlockPlatformProperties()
+      val buildContext = BuildContextImpl.createContext(home.communityRoot, properties)
+      val tasks = createBuildTasks(buildContext)
+      tasks.buildDistributions()
+    }
+  }
+}
+
+// TODO: Does BaseIdeaProperties add some stuff we don't need?
+private class SherlockPlatformProperties : BaseIdeaProperties() {
+  init {
+    platformPrefix = "SherlockPlatform"
+    applicationInfoModule = "intellij.idea.community.customization" // TODO: better to use own module.
+    useSplash = false
+    productLayout.buildAllCompatiblePlugins = false
+    productLayout.prepareCustomPluginRepositoryForPublishedPlugins = false
+    productLayout.productImplementationModules = listOf(
+      "intellij.platform.starter",
+      "intellij.idea.community.customization",
+    )
+    productLayout.bundledPluginModules = mutableListOf()
+    productLayout.pluginLayouts = persistentListOf()
+  }
+
+  override val baseFileName: String = "sherlock-platform"
+
+  override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform-$buildNumber"
+
+  override fun getSystemSelector(appInfo: ApplicationInfoProperties, buildNumber: String): String = "SherlockPlatform"
+
+  override fun createLinuxCustomizer(projectHome: String): LinuxDistributionCustomizer {
+    return object : LinuxDistributionCustomizer() {}
+  }
+
+  override fun createMacCustomizer(projectHome: String): MacDistributionCustomizer {
+    return object : MacDistributionCustomizer() {
+      init {
+        bundleIdentifier = "com.google.sherlock.platform"
+        icnsPath = "${projectHome}/build/conf/ideaCE/mac/images/idea.icns" // TODO
+      }
+    }
+  }
+
+  override fun createWindowsCustomizer(projectHome: String): WindowsDistributionCustomizer {
+    return object : WindowsDistributionCustomizer() {
+      init {
+        icoPath = "${projectHome}/build/conf/ideaCE/win/images/idea_CE.ico" // TODO
+      }
+    }
+  }
+}

--- a/build_sherlock_platform.sh
+++ b/build_sherlock_platform.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eu
+
+PROG_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+OUT="${PROG_DIR}/out/sherlock-platform"
+
+readonly AS_BUILD_NUMBER="$(sed 's/\.SNAPSHOT$//' build.txt)"
+
+BUILD_PROPERTIES=(
+  "-Dintellij.build.output.root=${OUT}"
+  "-Dbuild.number=${AS_BUILD_NUMBER}"
+  "-Dintellij.build.dev.mode=false"
+  "-Dcompile.parallel=true"
+  "-Dintellij.build.skip.build.steps=repair_utility_bundle_step,mac_dmg,mac_sign,mac_sit,windows_exe_installer,linux aarch64,windows aarch64" # TODO
+  "-Dintellij.build.incremental.compilation=true" # TODO
+  "-Dintellij.build.incremental.compilation.fallback.rebuild=false"
+)
+
+"${PROG_DIR}/platform/jps-bootstrap/jps-bootstrap.sh" "${BUILD_PROPERTIES[@]}" "${PROG_DIR}" intellij.idea.community.build SherlockPlatformBuild

--- a/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
+++ b/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
@@ -1,0 +1,33 @@
+<idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- TODO: can the Java plugin be excluded somehow? -->
+  <xi:include href="/META-INF/JavaIdePlugin.xml" xpointer="xpointer(/idea-plugin/*)"/>
+
+  <!--
+      IntelliJ 2024.2 [BEGIN]
+
+      Starting IntelliJ 2024.2, SettingsController and its extension point must be registered
+      because this file is missing:
+
+        <xi:include href="/META-INF/essential-modules.xml"/>
+
+      Both IdeaPlugin.xml and AndroidStudioPlugin.xml include essential-modules.xml transitively via:
+
+        <xi:include href="/META-INF/common-ide-modules.xml"/>
+
+      Including either one results in this error:
+
+        Product module intellij.platform.settings.local descriptor content
+        is not embedded - corrupted distribution...
+
+      This could be due to conflict with "essential-modules.xml" and
+      "common-ide-modules.xml".
+  -->
+  <extensions defaultExtensionNs="com.intellij">
+    <applicationService serviceInterface="com.intellij.platform.settings.SettingsController" serviceImplementation="com.intellij.platform.settings.local.SettingsControllerMediator" />
+  </extensions>
+
+  <extensionPoints>
+    <extensionPoint name="settingsController" interface="com.intellij.platform.settings.DelegatedSettingsController" />
+  </extensionPoints>
+  <!-- IntelliJ 2024.2 [END] -->
+</idea-plugin>

--- a/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
+++ b/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
@@ -1,33 +1,5 @@
 <idea-plugin xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- TODO: can the Java plugin be excluded somehow? -->
   <xi:include href="/META-INF/JavaIdePlugin.xml" xpointer="xpointer(/idea-plugin/*)"/>
-
-  <!--
-      IntelliJ 2024.2 [BEGIN]
-
-      Starting IntelliJ 2024.2, SettingsController and its extension point must be registered
-      because this file is missing:
-
-        <xi:include href="/META-INF/essential-modules.xml"/>
-
-      Both IdeaPlugin.xml and AndroidStudioPlugin.xml include essential-modules.xml transitively via:
-
-        <xi:include href="/META-INF/common-ide-modules.xml"/>
-
-      Including either one results in this error:
-
-        Product module intellij.platform.settings.local descriptor content
-        is not embedded - corrupted distribution...
-
-      This could be due to conflict with "essential-modules.xml" and
-      "common-ide-modules.xml".
-  -->
-  <extensions defaultExtensionNs="com.intellij">
-    <applicationService serviceInterface="com.intellij.platform.settings.SettingsController" serviceImplementation="com.intellij.platform.settings.local.SettingsControllerMediator" />
-  </extensions>
-
-  <extensionPoints>
-    <extensionPoint name="settingsController" interface="com.intellij.platform.settings.DelegatedSettingsController" />
-  </extensionPoints>
-  <!-- IntelliJ 2024.2 [END] -->
+  <xi:include href="/META-INF/essential-modules.xml"/>
 </idea-plugin>

--- a/community-resources/resources/idea/SherlockPlatformApplicationInfo.xml
+++ b/community-resources/resources/idea/SherlockPlatformApplicationInfo.xml
@@ -1,0 +1,9 @@
+<component xmlns="http://jetbrains.org/intellij/schema/application-info">
+  <version major="2024" minor="2.1"/>
+  <company name="Google" url="http://developer.android.com"/>
+  <build number="MP-__BUILD__" date="__BUILD_DATE__" majorReleaseDate="20240806" />
+  <logo url="/idea_community_logo.png"/><!-- TODO -->
+  <icon svg="/idea-ce.svg" svg-small="/idea-ce_16.svg"/><!-- TODO -->
+  <icon-eap svg="/idea-ce-eap.svg" svg-small="/idea-ce-eap_16.svg"/><!-- TODO -->
+  <names product="SherlockPlatform" fullname="Sherlock Platform" script="platform" motto="Customised IntelliJ Platform for Sherlock"/>
+</component>


### PR DESCRIPTION
Scripts that build a basic IntelliJ Platform version for Sherlock.

Steps to build: 
`./build_sherlock_platform.sh`

Steps to run:

1. `cd out/sherlock-platform/artifacts`
2.  Extract based on the OS
3. `cd sherlock-platform-242.21829/Sherlock\ Platform-2024.2.1/bin`
4. Run `sherlock-platform`
