### PR TITLE
Configured building of plugins through a dedicated Properties class.

### DIFF
--- a/build/src/SherlockPlatformBuild.kt
+++ b/build/src/SherlockPlatformBuild.kt
@@ -1,5 +1,17 @@
-// TODO: Copyright
-import kotlinx.collections.immutable.persistentListOf
+//Copyright 2024 Google LLC
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//https://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.intellij.build.*
 import org.jetbrains.intellij.build.impl.BuildContextImpl
@@ -11,54 +23,10 @@ object SherlockPlatformBuild {
   fun main() {
     runBlocking {
       val home = IdeaProjectLoaderUtil.guessCommunityHome(javaClass)
-      val properties = SherlockPlatformProperties()
+      val properties = SherlockProperties(home.communityRoot)
       val buildContext = BuildContextImpl.createContext(home.communityRoot, properties)
       val tasks = createBuildTasks(buildContext)
       tasks.buildDistributions()
-    }
-  }
-}
-
-// TODO: Does BaseIdeaProperties add some stuff we don't need?
-private class SherlockPlatformProperties : BaseIdeaProperties() {
-  init {
-    platformPrefix = "SherlockPlatform"
-    applicationInfoModule = "intellij.idea.community.customization" // TODO: better to use own module.
-    useSplash = false
-    productLayout.buildAllCompatiblePlugins = false
-    productLayout.prepareCustomPluginRepositoryForPublishedPlugins = false
-    productLayout.productImplementationModules = listOf(
-      "intellij.platform.starter",
-      "intellij.idea.community.customization",
-    )
-    productLayout.bundledPluginModules = mutableListOf()
-    productLayout.pluginLayouts = persistentListOf()
-  }
-
-  override val baseFileName: String = "sherlock-platform"
-
-  override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform-$buildNumber"
-
-  override fun getSystemSelector(appInfo: ApplicationInfoProperties, buildNumber: String): String = "SherlockPlatform"
-
-  override fun createLinuxCustomizer(projectHome: String): LinuxDistributionCustomizer {
-    return object : LinuxDistributionCustomizer() {}
-  }
-
-  override fun createMacCustomizer(projectHome: String): MacDistributionCustomizer {
-    return object : MacDistributionCustomizer() {
-      init {
-        bundleIdentifier = "com.google.sherlock.platform"
-        icnsPath = "${projectHome}/build/conf/ideaCE/mac/images/idea.icns" // TODO
-      }
-    }
-  }
-
-  override fun createWindowsCustomizer(projectHome: String): WindowsDistributionCustomizer {
-    return object : WindowsDistributionCustomizer() {
-      init {
-        icoPath = "${projectHome}/build/conf/ideaCE/win/images/idea_CE.ico" // TODO
-      }
     }
   }
 }

--- a/build/src/SherlockPlatformBuild.kt
+++ b/build/src/SherlockPlatformBuild.kt
@@ -1,21 +1,21 @@
-//Copyright 2024 Google LLC
-//
-//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//You may obtain a copy of the License at
-//
-//https://www.apache.org/licenses/LICENSE-2.0
-//
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
+/***
+ * Copyright 2024 Google LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+***/
 
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.intellij.build.*
 import org.jetbrains.intellij.build.impl.BuildContextImpl
-
 
 @Suppress("RAW_RUN_BLOCKING", "UNUSED")
 object SherlockPlatformBuild {

--- a/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
+++ b/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
@@ -9,6 +9,17 @@
       because this file is missing:
 
         <xi:include href="/META-INF/essential-modules.xml"/>
+
+      IdeaPlugin.xml includes essential-modules.xml transitively via:
+
+        <xi:include href="/META-INF/common-ide-modules.xml"/>
+
+      Including either essential-modules.xml or common-ide-modules.xml results in this error:
+
+        Product module intellij.platform.settings.local descriptor content
+        is not embedded - corrupted distribution...
+
+      This could be due to conflict with "essential-modules.xml" and "common-ide-modules.xml"
   -->
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceInterface="com.intellij.platform.settings.SettingsController" serviceImplementation="com.intellij.platform.settings.local.SettingsControllerMediator" />

--- a/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
+++ b/community-resources/resources/META-INF/SherlockPlatformPlugin.xml
@@ -9,18 +9,6 @@
       because this file is missing:
 
         <xi:include href="/META-INF/essential-modules.xml"/>
-
-      Both IdeaPlugin.xml and AndroidStudioPlugin.xml include essential-modules.xml transitively via:
-
-        <xi:include href="/META-INF/common-ide-modules.xml"/>
-
-      Including either one results in this error:
-
-        Product module intellij.platform.settings.local descriptor content
-        is not embedded - corrupted distribution...
-
-      This could be due to conflict with "essential-modules.xml" and
-      "common-ide-modules.xml".
   -->
   <extensions defaultExtensionNs="com.intellij">
     <applicationService serviceInterface="com.intellij.platform.settings.SettingsController" serviceImplementation="com.intellij.platform.settings.local.SettingsControllerMediator" />

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
@@ -1,0 +1,64 @@
+//Copyright 2024 Google LLC
+//
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at
+//
+//https://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+package org.jetbrains.intellij.build
+import java.nio.file.Path
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * Configures the Sherlock distribution by specifying bundled plugins, JVM args, extra files, and more.
+ * See also: BaseIdeaProperties, IdeaCommunityProperties.
+ */
+class SherlockProperties(home: Path) : BaseIdeaProperties() {
+    init {
+      platformPrefix = "SherlockPlatform"
+      applicationInfoModule = "intellij.idea.community.customization" // TODO: better to use own module.
+      useSplash = true
+      productLayout.buildAllCompatiblePlugins = false
+      productLayout.prepareCustomPluginRepositoryForPublishedPlugins = false
+      productLayout.productImplementationModules = listOf(
+        "intellij.platform.starter",
+        "intellij.idea.community.customization",
+      )
+      productLayout.bundledPluginModules = mutableListOf()
+      productLayout.pluginLayouts = persistentListOf()
+    }
+
+    override val baseFileName: String = "sherlock-platform"
+
+    override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform-$buildNumber"
+
+    override fun getSystemSelector(appInfo: ApplicationInfoProperties, buildNumber: String): String = "SherlockPlatform"
+
+    override fun createLinuxCustomizer(projectHome: String): LinuxDistributionCustomizer {
+      return object : LinuxDistributionCustomizer() {}
+    }
+
+    override fun createMacCustomizer(projectHome: String): MacDistributionCustomizer {
+      return object : MacDistributionCustomizer() {
+        init {
+          bundleIdentifier = "com.google.sherlock.platform"
+          icnsPath = "${projectHome}/build/conf/ideaCE/mac/images/idea.icns" // TODO
+        }
+      }
+    }
+
+    override fun createWindowsCustomizer(projectHome: String): WindowsDistributionCustomizer {
+      return object : WindowsDistributionCustomizer() {
+        init {
+          icoPath = "${projectHome}/build/conf/ideaCE/win/images/idea_CE.ico" // TODO
+        }
+      }
+    }
+}

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
@@ -1,16 +1,17 @@
-//Copyright 2024 Google LLC
-//
-//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//You may obtain a copy of the License at
-//
-//https://www.apache.org/licenses/LICENSE-2.0
-//
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
+/***
+ * Copyright 2024 Google LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ***/
 
 package org.jetbrains.intellij.build
 import java.nio.file.Path
@@ -31,6 +32,7 @@ class SherlockProperties(home: Path) : BaseIdeaProperties() {
         "intellij.platform.starter",
         "intellij.idea.community.customization",
       )
+      // TODO: Bundle plugin here
       productLayout.bundledPluginModules = mutableListOf()
       productLayout.pluginLayouts = persistentListOf()
     }


### PR DESCRIPTION
This PR is based on #4 and should be merged only after it gets merged.

1. Created a dedicated Properties class for Sherlock that will eventually be used to configure the Sherlock distribution by specifying bundled plugins, branding etc. 
2.  Added Copyright to existing files. 

This doesn't change the functionality of the code.