### PR TITLE
Build and run Sherlock from inside IntelliJ IDEA

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -388,6 +388,7 @@
       <module fileurl="file://$PROJECT_DIR$/community-resources/intellij.idea.community.customization.iml" filepath="$PROJECT_DIR$/community-resources/intellij.idea.community.customization.iml" />
       <module fileurl="file://$PROJECT_DIR$/intellij.idea.community.main.iml" filepath="$PROJECT_DIR$/intellij.idea.community.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/intellij.idea.community.main.android.iml" filepath="$PROJECT_DIR$/intellij.idea.community.main.android.iml" />
+      <module fileurl="file://$PROJECT_DIR$/intellij.idea.community.main.sherlock.iml" filepath="$PROJECT_DIR$/intellij.idea.community.main.sherlock.iml" />
       <module fileurl="file://$PROJECT_DIR$/idea/customization/base/intellij.idea.customization.base.iml" filepath="$PROJECT_DIR$/idea/customization/base/intellij.idea.customization.base.iml" />
       <module fileurl="file://$PROJECT_DIR$/build/launch/intellij.idea.tools.launch.iml" filepath="$PROJECT_DIR$/build/launch/intellij.idea.tools.launch.iml" />
       <module fileurl="file://$PROJECT_DIR$/java/openapi/intellij.java.iml" filepath="$PROJECT_DIR$/java/openapi/intellij.java.iml" />

--- a/.idea/runConfigurations/Sherlock.xml
+++ b/.idea/runConfigurations/Sherlock.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Sherlock" type="Application" factoryName="Application" singleton="true">
+    <option name="ALTERNATIVE_JRE_PATH" value="BUNDLED" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/system/idea/log/idea.log" />
+    <log_file alias="build.log" path="$PROJECT_DIR$/system/idea/log/build-log/build.log" />
+    <option name="MAIN_CLASS_NAME" value="com.intellij.idea.Main" />
+    <module name="intellij.idea.community.main.sherlock" />
+    <shortenClasspath name="ARGS_FILE" />
+    <option name="VM_PARAMETERS" value="-Xmx2g -XX:ReservedCodeCacheSize=240m -XX:SoftRefLRUPolicyMSPerMB=50 -XX:MaxJavaStackTraceDepth=10000 -ea -Dsun.io.useCanonCaches=false -Dapple.laf.useScreenMenuBar=true -Dsun.awt.disablegrab=true -Didea.jre.check=true -Didea.is.internal=true -Didea.debug.mode=true -Djdk.attach.allowAttachSelf -Dfus.internal.test.mode=true -Dkotlinx.coroutines.debug=off -Djdk.module.illegalAccess.silent=true -Didea.config.path=../config/idea -Didea.system.path=../system/idea -Didea.initially.ask.config=true --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/jdk.internal.vm=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED --add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED --add-opens=java.desktop/com.apple.laf=ALL-UNNAMED --add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED --add-opens=java.desktop/java.awt.dnd.peer=ALL-UNNAMED --add-opens=java.desktop/java.awt.event=ALL-UNNAMED --add-opens=java.desktop/java.awt.image=ALL-UNNAMED --add-opens=java.desktop/java.awt.peer=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/javax.swing.plaf.basic=ALL-UNNAMED --add-opens=java.desktop/javax.swing.text=ALL-UNNAMED --add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED --add-opens=java.desktop/javax.swing=ALL-UNNAMED --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED --add-opens=java.desktop/sun.awt.datatransfer=ALL-UNNAMED --add-opens=java.desktop/sun.awt.image=ALL-UNNAMED --add-opens=java.desktop/sun.awt.windows=ALL-UNNAMED --add-opens=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.desktop/sun.font=ALL-UNNAMED --add-opens=java.desktop/sun.java2d=ALL-UNNAMED --add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED --add-opens=java.desktop/sun.lwawt=ALL-UNNAMED --add-opens=java.desktop/sun.swing=ALL-UNNAMED --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-opens=jdk.jdi/com.sun.tools.jdi=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED -Didea.platform.prefix=SherlockPlatform -Djava.system.class.loader=com.intellij.util.lang.PathClassLoader" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/bin" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="60786" />
+      <option name="TRANSPORT" value="0" />
+      <option name="LOCAL" value="true" />
+    </RunnerSettings>
+    <RunnerSettings RunnerId="Profile " />
+    <RunnerSettings RunnerId="Run" />
+    <ConfigurationWrapper RunnerId="Debug" />
+    <ConfigurationWrapper RunnerId="Profile " />
+    <ConfigurationWrapper RunnerId="Run" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+      <option name="BuildArtifacts" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/community-resources/resources/idea/SherlockPlatformApplicationInfo.xml
+++ b/community-resources/resources/idea/SherlockPlatformApplicationInfo.xml
@@ -1,7 +1,7 @@
 <component xmlns="http://jetbrains.org/intellij/schema/application-info">
   <version major="2024" minor="2.1"/>
   <company name="Google" url="http://developer.android.com"/>
-  <build number="MP-__BUILD__" date="__BUILD_DATE__" majorReleaseDate="20240806" />
+  <build number="IC-__BUILD__" date="__BUILD_DATE__" majorReleaseDate="20240806" />
   <logo url="/idea_community_logo.png"/><!-- TODO -->
   <icon svg="/idea-ce.svg" svg-small="/idea-ce_16.svg"/><!-- TODO -->
   <icon-eap svg="/idea-ce-eap.svg" svg-small="/idea-ce-eap_16.svg"/><!-- TODO -->

--- a/getPlugins.sh
+++ b/getPlugins.sh
@@ -1,7 +1,24 @@
 #!/bin/bash
 
+# This script clones the Jetbrains/android repository. Note that the tag
+# of the android repo must match the tag of the IntelliJ repo, otherwise
+# there can be build errors.
+
+# This value does not contain the actual snapshot value.
+readonly AS_BUILD_NUMBER="$(sed 's/\.SNAPSHOT$//' build.txt)"
+
+# When we pull a new IntelliJ platform, we must update this SNAPSHOT value.
+# This can be automated (e.g., search all git tags for this prefix), but
+# the benefit doesn't seem worth the time spent on automating it.
+readonly SNAPSHOT="142"
+
+readonly TAG="idea/${AS_BUILD_NUMBER}.${SNAPSHOT}"
+
+echo "Cloning Jetbrains/android repository using the following tag: ${TAG}"
+
 if [ "$1" == "--shallow" ]; then
-    git clone git://git.jetbrains.org/idea/android.git android --depth 1
+    git clone git://git.jetbrains.org/idea/android.git android --depth 1 --branch "${TAG}"
 else
-    git clone git://git.jetbrains.org/idea/android.git android
+    echo "Warning: Cloning with the entire history. Use the --shallow flag to clone faster."
+    git clone git://git.jetbrains.org/idea/android.git android --branch "${TAG}"
 fi

--- a/intellij.idea.community.main.sherlock.iml
+++ b/intellij.idea.community.main.sherlock.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module relativePaths="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="intellij.idea.community.customization" />
+    <orderEntry type="module" module-name="intellij.platform.starter" />
+    <orderEntry type="module" module-name="intellij.platform.extensions" />
+    <orderEntry type="module" module-name="intellij.xml.impl" />
+  </component>
+</module>


### PR DESCRIPTION
This change:

1. Adds an `.iml` file that represents the Sherlock platform. The `.iml` contains the absolute minimum for the Sherlock platform. Its contents should be kept in sync (or mostly similar) with the list of modules used in the `build_sherlock_platform.sh` script. Currently, it has 2 extra modules that were needed to avoid runtime exceptions.
2. Adds a run configuration that is identical to the `IDEA` run configuration except that (1) it uses the Sherlock `.iml` file for the classpath, (2) uses SherlockPlatform as the platorm prefix.
3. Updates `getPlugins.sh` to download the android repo at the correct tag automatically.

Using this change, one can:

1. Clone the `android-graphics/intellij-community` repo
2. Run `./getPlugins.sh --shallow`
3. Open the project in IntelliJ IDEA
4. Switch to Sherlock run configuration
5. Hit Run/Debug to build and launch Sherlock