### PR TITLE
Don't build for mac-x64 platform

### DIFF
--- a/build_sherlock_platform.sh
+++ b/build_sherlock_platform.sh
@@ -12,7 +12,7 @@ BUILD_PROPERTIES=(
   "-Dbuild.number=${AS_BUILD_NUMBER}"
   "-Dintellij.build.dev.mode=false"
   "-Dcompile.parallel=true"
-  "-Dintellij.build.skip.build.steps=repair_utility_bundle_step,mac_dmg,mac_sign,mac_sit,windows_exe_installer,linux aarch64,windows aarch64" # TODO
+  "-Dintellij.build.skip.build.steps=repair_utility_bundle_step,mac_dmg,mac_sign,mac_sit,windows_exe_installer,linux aarch64,windows aarch64,mac x64" # TODO
   "-Dintellij.build.incremental.compilation=true" # TODO
   "-Dintellij.build.incremental.compilation.fallback.rebuild=false"
 )


### PR DESCRIPTION
On MacOS, we only need to support arm64. No need to build the x64 version.